### PR TITLE
add a method to derive a component object

### DIFF
--- a/fleetdb/methods_test.go
+++ b/fleetdb/methods_test.go
@@ -127,13 +127,18 @@ func TestRecordToComponent(t *testing.T) {
 		t.Parallel()
 
 		record := &ss.ServerComponent{
-			UUID:                uuid.New(),
-			ServerUUID:          uuid.New(),
-			Name:                "BIOS",
-			Vendor:              "Dell",
-			Model:               "Version X",
-			Serial:              "DEF789",
-			Attributes:          []ss.Attributes{},
+			UUID:       uuid.New(),
+			ServerUUID: uuid.New(),
+			Name:       "BIOS",
+			Vendor:     "Dell",
+			Model:      "Version X",
+			Serial:     "DEF789",
+			Attributes: []ss.Attributes{
+				{
+					Namespace: "sh.hollow.alloy.inband.metadata",
+					Data:      json.RawMessage(`{"ID": "my-id"}`),
+				},
+			},
 			VersionedAttributes: []ss.VersionedAttributes{},
 			ComponentTypeName:   "BIOS",
 			ComponentTypeSlug:   "bios",
@@ -149,6 +154,8 @@ func TestRecordToComponent(t *testing.T) {
 		require.Equal(t, record.Model, got.Model)
 		require.Equal(t, record.Serial, got.Serial)
 		require.Equal(t, record.UpdatedAt, got.UpdatedAt)
+		require.NotNil(t, got.Attributes)
+		require.Equal(t, "my-id", got.Attributes.ID)
 	})
 	t.Run("out-of-band populates empty fields", func(t *testing.T) {
 		t.Parallel()

--- a/fleetdb/methods_test.go
+++ b/fleetdb/methods_test.go
@@ -157,7 +157,7 @@ func TestRecordToComponent(t *testing.T) {
 		require.NotNil(t, got.Attributes)
 		require.Equal(t, "my-id", got.Attributes.ID)
 	})
-	t.Run("out-of-band populates empty fields", func(t *testing.T) {
+	t.Run("populate empty fields", func(t *testing.T) {
 		t.Parallel()
 		record := &ss.ServerComponent{
 			UUID:       uuid.New(),
@@ -169,7 +169,7 @@ func TestRecordToComponent(t *testing.T) {
 			Attributes: []ss.Attributes{},
 			VersionedAttributes: []ss.VersionedAttributes{
 				{
-					Namespace: FirmwareVersionOutofbandNS,
+					Namespace: FirmwareVersionInbandNS,
 					Data:      json.RawMessage(`{"firmware": {"installed": "1.2.3"}}`),
 				},
 				{
@@ -189,7 +189,7 @@ func TestRecordToComponent(t *testing.T) {
 		require.Equal(t, "1.2.3", got.Firmware.Installed)
 		require.Equal(t, "ok", got.Status.State)
 	})
-	t.Run("in-band trumps out-of-band", func(t *testing.T) {
+	t.Run("specific overrides", func(t *testing.T) {
 		t.Parallel()
 		record := &ss.ServerComponent{
 			UUID:       uuid.New(),
@@ -226,8 +226,8 @@ func TestRecordToComponent(t *testing.T) {
 
 		got, err := RecordToComponent(record)
 		require.NoError(t, err)
-		require.Equal(t, "1.2.3-45", got.Firmware.Installed)
-		require.Equal(t, "ok, but could be better", got.Status.State)
+		require.Equal(t, "1.2.3", got.Firmware.Installed, "firmware version does not favor out-of-band")
+		require.Equal(t, "ok, but could be better", got.Status.State, "status does not favor in-band")
 	})
 	t.Run("malformed variable attribute returns an error", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
Added a method to return a rivets Component from FleetDB data. I wanted to handle only a single record at a time and return an error to give the caller more flexibility than ConvertComponents does. Also this new function reports in-band inventory data preferentially.