### PR TITLE
Consumer add

### DIFF
--- a/events/controller/controller.go
+++ b/events/controller/controller.go
@@ -184,6 +184,7 @@ func (n *NatsController) Connect(ctx context.Context) error {
 			"connect-time":  time.Since(startTS).String(),
 		},
 	).Info("connected to event stream as controller")
+	registerNATSConnectTimeMetric(startTS)
 
 	return nil
 }

--- a/events/controller/controller.go
+++ b/events/controller/controller.go
@@ -153,6 +153,8 @@ func (n *NatsController) Connect(ctx context.Context) error {
 	)
 	defer span.End()
 
+	startTS := time.Now()
+
 	errInit := errors.New("nats broker init error")
 	stream, err := events.NewNatsBroker(n.natsConfig)
 	if err != nil {
@@ -175,9 +177,11 @@ func (n *NatsController) Connect(ctx context.Context) error {
 	n.startLivenessCheckin(ctx)
 	n.logger.WithFields(
 		logrus.Fields{
-			"ID":            n.controllerID,
+			"hostname":      n.hostname,
+			"facility":      n.facilityCode,
 			"replica-count": n.natsConfig.KVReplicationFactor,
 			"concurrency":   n.concurrency,
+			"connect-time":  time.Since(startTS).String(),
 		},
 	).Info("connected to event stream as controller")
 

--- a/events/controller/metrics.go
+++ b/events/controller/metrics.go
@@ -15,6 +15,7 @@ var (
 	metricsNATSErrors              *prometheus.CounterVec
 	metricsEventCounter            *prometheus.CounterVec
 	metricsConditionRunTimeSummary *prometheus.SummaryVec
+	metricsNATSConnectTime         *prometheus.SummaryVec
 )
 
 func init() {
@@ -42,6 +43,13 @@ func init() {
 		[]string{"condition", "state"},
 	)
 
+	metricsNATSConnectTime = promauto.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "nats_connection_time",
+			Help: "A summary metric to measure the time taken to connect and subscribe to the NATS Jetstream",
+		},
+		[]string{},
+	)
 }
 
 // spanEvent adds a span event along with the given attributes.
@@ -57,6 +65,10 @@ func spanEvent(span trace.Span, cond *condition.Condition, controllerID, event s
 
 func metricsNATSError(op string) {
 	metricsNATSErrors.WithLabelValues(op).Inc()
+}
+
+func registerNATSConnectTimeMetric(startTS time.Time) {
+	metricsNATSConnectTime.With(prometheus.Labels{}).Observe(time.Since(startTS).Seconds())
 }
 
 func metricsEventsCounter(valid bool, response string) {


### PR DESCRIPTION
Fixes incorrect consumer add on clients with high latency connections to the server.

Since we know the stream name, consumer name - just attempt to get ConsumerInfo on the known consumer.
