### PR TITLE
FS-1346 Add biosControl condition

### DIFF
--- a/condition/bios_control.go
+++ b/condition/bios_control.go
@@ -1,0 +1,46 @@
+package condition
+
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
+
+type (
+	BiosControlAction string
+)
+
+const (
+	// BiosControl identifies the Condition kind to configure the BIOS.
+	BiosControl Kind = "biosControl"
+
+	// ResetSettings will reset the BIOS to default settings.
+	ResetSettings BiosControlAction = "reset_settings"
+)
+
+// BiosControlTaskParameters are the parameters that are passed for the BiosControl condition.
+type BiosControlTaskParameters struct {
+	// Identifier for the Asset in the Asset store.
+	//
+	// Required: true
+	AssetID uuid.UUID `json:"asset_id"`
+
+	// The bios control action to be performed
+	//
+	// Required: true
+	Action BiosControlAction `json:"action"`
+}
+
+func NewBiosControlTaskParameters(assetID uuid.UUID, action BiosControlAction) *BiosControlTaskParameters {
+	return &BiosControlTaskParameters{
+		AssetID: assetID,
+		Action:  action,
+	}
+}
+
+func NewBiosControlParametersFromCondition(condition *Condition) (*BiosControlTaskParameters, error) {
+	b := &BiosControlTaskParameters{}
+	err := json.Unmarshal(condition.Parameters, b)
+
+	return b, err
+}

--- a/events/controller/controller.go
+++ b/events/controller/controller.go
@@ -289,7 +289,7 @@ func (n *NatsController) processEvents(ctx context.Context) error {
 		if err != nil {
 			eventAcknowleger.nak()
 
-			return errors.Wrap(errProcessEvent, ctx.Err().Error())
+			return errors.Wrap(errProcessEvent, err.Error())
 		}
 
 		// spawn msg process handler


### PR DESCRIPTION
- Add the Kind, action, task parameters struct, and functions for the biosControl condition.
- Fix a minor bug with error return causing a nil pointer dereference.