### PR TITLE
Add fleetdb API helper methods for firmware sets

### DIFF
--- a/fleetdb/consts.go
+++ b/fleetdb/consts.go
@@ -1,43 +1,43 @@
 package fleetdb
 
 const (
-	// Serverservice attribute namespace for device vendor, model, serial attributes.
-	ServerAttributeNSVendor = "sh.hollow.alloy.server_vendor_attributes"
+	// FleetDB attribute namespace for device vendor, model, serial attributes.
+	ServerVendorAttributeNS = "sh.hollow.alloy.server_vendor_attributes"
 
-	// Serverservice attribute namespace for the BMC address.
+	// FleetDB attribute namespace for the BMC address.
 	ServerAttributeNSBmcAddress = "sh.hollow.bmc_info"
 
-	// Serverservice attribute namespace for firmware set labels.
-	FirmwareAttributeNSFirmwareSetLabels = "sh.hollow.firmware_set.labels"
+	// FleetDB attribute namespace for firmware set labels.
+	FirmwareSetAttributeNS = "sh.hollow.firmware_set.labels"
 
-	// Serverservice attribute namespace for inband firmware information.
+	// FleetDB attribute namespace for inband firmware information.
 	FirmwareVersionInbandNS = "sh.hollow.alloy.inband.firmware"
 
-	// Serverservice attribute namespace for outofband firmware information.
+	// FleetDB attribute namespace for outofband firmware information.
 	FirmwareVersionOutofbandNS = "sh.hollow.alloy.outofband.firmware"
 
-	// Serverservice attribute namespace for outofband bios configuration.
+	// FleetDB attribute namespace for outofband bios configuration.
 	BiosConfigOutofbandNS = "sh.hollow.alloy.outofband.bios_configuration"
 
-	// Serverservice attribute namespace for inband bios configuration.
+	// FleetDB attribute namespace for inband bios configuration.
 	BiosConfigInbandNS = "sh.hollow.alloy.inband.bios_configuration"
 
-	// Serverservice attribute namespace for inband component attributes/metadata.
+	// FleetDB attribute namespace for inband component attributes/metadata.
 	ComponentAttributeInbandNS = "sh.hollow.alloy.inband.metadata"
 
-	// Serverservice attribute namespace for outofband component attributes/metadata.
+	// FleetDB attribute namespace for outofband component attributes/metadata.
 	ComponentAttributeOutofbandNS = "sh.hollow.alloy.outofband.metadata"
 
-	// Serverservice attribute for installed firmware.
+	// FleetDB attribute for installed firmware.
 	FirmwareVersionNSInstalledAttribute = "firmware.installed"
 
-	// Serverservice attribute namespace for inband component status information.
+	// FleetDB attribute namespace for inband component status information.
 	StatusInbandNS = "sh.hollow.alloy.inband.status"
 
-	// Serverservice attribute namespace for outofband component status information.
+	// FleetDB attribute namespace for outofband component status information.
 	StatusOutofbandNS = "sh.hollow.alloy.outofband.status"
 
-	// Serverservice attribute for component health status.
+	// FleetDB attribute for component health status.
 	StatusNSHealthAttribute = "status.health"
 
 	// Serserverservice attribute for errors that occurred when connecting/collecting inventory from the bmc are stored here.

--- a/fleetdb/firmware.go
+++ b/fleetdb/firmware.go
@@ -1,0 +1,140 @@
+package fleetdb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	bmclibcomm "github.com/bmc-toolbox/common"
+	fleetdbapi "github.com/metal-toolbox/fleetdb/pkg/api/v1"
+)
+
+var (
+	ErrAttributeFromLabel = errors.New("error creating Attribute from Label")
+	ErrLabelFromAttribute = errors.New("error creating Label from Attribute")
+	ErrFwSetByVendorModel = errors.New("error identifying firmware set by server vendor, model")
+)
+
+func AttributeFromLabels(ns string, labels map[string]string) (*fleetdbapi.Attributes, error) {
+	data, err := json.Marshal(labels)
+	if err != nil {
+		return nil, errors.Wrap(ErrAttributeFromLabel, err.Error())
+	}
+
+	return &fleetdbapi.Attributes{
+		Namespace: ns,
+		Data:      data,
+	}, nil
+}
+
+// AttributeByNamespace returns the fleetdb attribute in the slice that matches the namespace
+func AttributeByNamespace(ns string, attributes []fleetdbapi.Attributes) *fleetdbapi.Attributes {
+	for _, attribute := range attributes {
+		if attribute.Namespace == ns {
+			return &attribute
+		}
+	}
+
+	return nil
+}
+
+// VendorModelFromAttrs unpacks the attributes payload to return the vendor, model attributes for a server
+func VendorModelFromAttrs(attrs []fleetdbapi.Attributes) (vendor, model string) {
+	attr := AttributeByNamespace(ServerVendorAttributeNS, attrs)
+	if attr == nil {
+		return "", ""
+	}
+
+	data := map[string]string{}
+	if err := json.Unmarshal(attr.Data, &data); err != nil {
+		return "", ""
+	}
+
+	return bmclibcomm.FormatVendorName(data["vendor"]), bmclibcomm.FormatProductName(data["model"])
+}
+
+// FirmwareSetIDByVendorModel returns the firmware set ID matched by the vendor, model attributes
+func FirmwareSetIDByVendorModel(ctx context.Context, vendor, model string, client *fleetdbapi.Client) (uuid.UUID, error) {
+	fwSet, err := FirmwareSetByVendorModel(ctx, vendor, model, client)
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	log.Printf(
+		"fw sets identified for vendor: %s, model: %s, fwset: %s\n",
+		vendor,
+		model,
+		fwSet[0].UUID.String(),
+	)
+
+	return fwSet[0].UUID, nil
+}
+
+// FirmwareSetByVendorModel returns the firmware set matched by the vendor, model attributes
+func FirmwareSetByVendorModel(ctx context.Context, vendor, model string, client *fleetdbapi.Client) ([]fleetdbapi.ComponentFirmwareSet, error) {
+	vendor = strings.TrimSpace(vendor)
+	if vendor == "" {
+		return []fleetdbapi.ComponentFirmwareSet{}, errors.Wrap(
+			ErrFwSetByVendorModel,
+			"got empty vendor attribute",
+		)
+	}
+
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return []fleetdbapi.ComponentFirmwareSet{}, errors.Wrap(
+			ErrFwSetByVendorModel,
+			"got empty model attribute",
+		)
+	}
+
+	// ?attr=sh.hollow.firmware_set.labels~vendor~eq~dell&attr=sh.hollow.firmware_set.labels~model~eq~r750&attr=sh.hollow.firmware_set.labels~latest~eq~false
+	// list latest, default firmware sets by vendor, model attributes
+	fwSetListparams := &fleetdbapi.ComponentFirmwareSetListParams{
+		AttributeListParams: []fleetdbapi.AttributeListParams{
+			{
+				Namespace: FirmwareSetAttributeNS,
+				Keys:      []string{"vendor"},
+				Operator:  "eq",
+				Value:     strings.ToLower(vendor),
+			},
+			{
+				Namespace: FirmwareSetAttributeNS,
+				Keys:      []string{"model"},
+				Operator:  "like",
+				Value:     strings.ToLower(model),
+			},
+			{
+				Namespace: FirmwareSetAttributeNS,
+				Keys:      []string{"latest"}, // latest indicates the most current revision of the firmware set.
+				Operator:  "eq",
+				Value:     "true",
+			},
+			{
+				Namespace: FirmwareSetAttributeNS,
+				Keys:      []string{"default"}, // default indicates the firmware set does not belong to an org/project.
+				Operator:  "eq",
+				Value:     "true",
+			},
+		},
+	}
+
+	fwSet, _, err := client.ListServerComponentFirmwareSet(ctx, fwSetListparams)
+	if err != nil {
+		return []fleetdbapi.ComponentFirmwareSet{}, errors.Wrap(ErrFwSetByVendorModel, err.Error())
+	}
+
+	if len(fwSet) == 0 {
+		return []fleetdbapi.ComponentFirmwareSet{}, errors.Wrap(
+			ErrFwSetByVendorModel,
+			fmt.Sprintf("no fw sets identified for vendor: %s, model: %s", vendor, model),
+		)
+	}
+
+	return fwSet, nil
+}

--- a/fleetdb/methods.go
+++ b/fleetdb/methods.go
@@ -186,7 +186,7 @@ func ConvertServer(s *ss.Server) *rt.Server {
 				server.BMCAddress = bmcAttr.Address
 			}
 
-		case ServerAttributeNSVendor:
+		case ServerVendorAttributeNS:
 			svmAttr := ServerVendorAttribute{}
 			if err := UnpackAttribute(&attr, &svmAttr); err == nil {
 				server.Vendor = svmAttr.Vendor


### PR DESCRIPTION
These common methods were pending a move into rivets,
https://github.com/metal-toolbox/mctl/blob/9d20393342f72e2d12083d92bf8c32e861b22038/cmd/common.go#L111