### PR TITLE
Periodic status updates

### DIFF
--- a/condition/status.go
+++ b/condition/status.go
@@ -50,6 +50,7 @@ const (
 
 // StatusValue is the canonical structure for reporting status of an ongoing task
 type StatusValue struct {
+	CreatedAt  time.Time       `json:"created"`
 	UpdatedAt  time.Time       `json:"updated"`
 	WorkerID   string          `json:"worker"`
 	Target     string          `json:"target"`

--- a/condition/status_test.go
+++ b/condition/status_test.go
@@ -191,3 +191,94 @@ func TestCheckConditionInProgress(t *testing.T) {
 		})
 	}
 }
+
+func TestTaskStatusRecord(t *testing.T) {
+	tests := []struct {
+		name           string
+		appendStatus   string
+		updateStatus   map[string]string
+		appendStatuses []string
+		wantStatuses   []string
+	}{
+		{
+			"single status record appended",
+			"works",
+			nil,
+			nil,
+			[]string{"works"},
+		},
+		{
+			"multiple status record appended",
+			"",
+			nil,
+			[]string{"a", "b", "c"},
+			[]string{"a", "b", "c"},
+		},
+		{
+			"dup status excluded",
+			"",
+			nil,
+			[]string{"a", "a", "b", "c"},
+			[]string{"a", "b", "c"},
+		},
+		{
+			"empty status excluded",
+			"",
+			nil,
+			[]string{"a", "", "", "c"},
+			[]string{"a", "c"},
+		},
+		{
+			"truncates long set of statuses",
+			"",
+			nil,
+			[]string{"a", "b", "c", "d", "e", "f"},
+			[]string{"b", "c", "d", "e", "f"},
+		},
+		{
+			"update a status record",
+			"",
+			map[string]string{"b": "updated", "d": "also updated"},
+			[]string{"a", "b", "c", "d", "e"},
+			[]string{"a", "updated", "c", "also updated", "e"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sr := NewTaskStatusRecord("")
+
+			if tc.appendStatus != "" {
+				sr.Append(tc.appendStatus)
+
+				assert.Equal(t, tc.appendStatus, sr.StatusMsgs[0].Msg)
+				assert.False(t, sr.StatusMsgs[0].Timestamp.IsZero())
+			}
+
+			// continue with other tests when theres no appendStatuses
+			if tc.appendStatuses == nil {
+				return
+			}
+
+			for _, s := range tc.appendStatuses {
+				sr.Append(s)
+			}
+
+			// append statuses - to test Update()
+			if tc.updateStatus != nil {
+				for k, v := range tc.updateStatus {
+					sr.Update(k, v)
+				}
+			}
+
+			assert.Equal(t, len(tc.wantStatuses), len(sr.StatusMsgs))
+			for idx, w := range tc.wantStatuses {
+				assert.Equal(t, w, sr.StatusMsgs[idx].Msg)
+				assert.False(t, sr.StatusMsgs[idx].Timestamp.IsZero())
+			}
+
+			// test Last() method
+			assert.Equal(t, tc.appendStatuses[len(tc.appendStatuses)-1], sr.Last())
+		})
+	}
+}

--- a/condition/types.go
+++ b/condition/types.go
@@ -110,6 +110,9 @@ type Condition struct {
 	// ID is the identifier for this condition.
 	ID uuid.UUID `json:"id"`
 
+	// Target is the identifier for the target server this Condition is applicable for.
+	Target uuid.UUID `json:"target"`
+
 	// Kind is one of Kind.
 	Kind Kind `json:"kind,omitempty"`
 

--- a/condition/types.go
+++ b/condition/types.go
@@ -22,6 +22,10 @@ const (
 
 	// ConditionStructVersion identifies the condition struct revision
 	ConditionStructVersion string = "1.1"
+
+	// StaleConditionThreshold is the period after which the Condition Orchestrator will
+	// attempt to reconcile the Condition.
+	StaleThreshold = 15 * time.Minute
 )
 
 // State is the state value of a Condition

--- a/events/controller/controller.go
+++ b/events/controller/controller.go
@@ -233,7 +233,6 @@ Loop:
 			if err := n.processEvents(ctx); err != nil {
 				return errors.Wrap(errListenEvents, err.Error())
 			}
-
 		case <-ctx.Done():
 			if n.dispatched > 0 {
 				continue
@@ -475,6 +474,7 @@ func (n *NatsController) runConditionHandlerWithMonitor(ctx context.Context, con
 			select {
 			case <-ticker.C:
 				eventStatusSet.inProgress()
+				conditionStatusPublisher.UpdateTimestamp(ctx)
 			case <-doneCh:
 				break Loop
 			}

--- a/events/controller/controller.go
+++ b/events/controller/controller.go
@@ -31,7 +31,7 @@ const (
 	// Default concurrency
 	concurrency = 2
 	// event ACK in progress interval
-	ackInProgressInterval = 1 * time.Second
+	ackInProgressInterval = 30 * time.Second
 	// controller check in interval
 	checkinInterval = 30 * time.Second
 	// default number of KV replicas for created NATS buckets

--- a/events/controller/controller.go
+++ b/events/controller/controller.go
@@ -34,6 +34,8 @@ const (
 	ackInProgressInterval = 30 * time.Second
 	// controller check in interval
 	checkinInterval = 30 * time.Second
+	//  controller considered dead after this period
+	LivenessStaleThreshold = checkinInterval * 4
 	// default number of KV replicas for created NATS buckets
 	kvReplicationFactor = 3
 )

--- a/events/controller/controller.go
+++ b/events/controller/controller.go
@@ -31,15 +31,14 @@ const (
 	pullEventTimeout = 5 * time.Second
 	// Default concurrency
 	concurrency = 2
-	// periodically publish an updated status
-	statusInterval = 30 * time.Second
-	// condition status considered stale after this period
-	StatusStaleThreshold = statusInterval * 4
-
 	// controller check in interval
 	checkinInterval = 30 * time.Second
+	// periodically publish an updated status
+	statusInterval = checkinInterval
+	// condition status considered stale after this period
+	StatusStaleThreshold = condition.StaleThreshold
 	//  controller considered dead after this period
-	LivenessStaleThreshold = checkinInterval * 4
+	LivenessStaleThreshold = condition.StaleThreshold
 	// default number of KV replicas for created NATS buckets
 	kvReplicationFactor = 3
 )

--- a/events/controller/controller_test.go
+++ b/events/controller/controller_test.go
@@ -275,6 +275,7 @@ func TestRunConditionHandlerWithMonitor(t *testing.T) {
 	ctx := context.Background()
 	cond := &condition.Condition{Kind: condition.FirmwareInstall}
 	publisher := NewMockConditionStatusPublisher(t)
+	publisher.On("UpdateTimestamp", mock.Anything).Return(nil)
 
 	message := events.NewMockMessage(t)
 	message.On("InProgress").Return(nil)
@@ -304,6 +305,9 @@ func TestRunConditionHandlerWithMonitor(t *testing.T) {
 
 	message.AssertExpectations(t)
 	handler.AssertExpectations(t)
+	publisher.AssertExpectations(t)
 	assert.GreaterOrEqual(t, len(message.Calls), 9, "expect multiple ackInprogress")
+	assert.GreaterOrEqual(t, len(publisher.Calls), 9, "expect multiple condition TS updates")
 	assert.Equal(t, 1, len(handler.Calls), "expect handler to be called once")
+
 }

--- a/events/controller/liveness.go
+++ b/events/controller/liveness.go
@@ -28,7 +28,7 @@ func (n *NatsController) checkinKVOpts() []kv.Option {
 	return opts
 }
 
-// This starts a go-routine to peridocally check in with the NATS kv
+// This starts a go-routine to peridically check in with the NATS kv
 func (n *NatsController) startLivenessCheckin(ctx context.Context) {
 	once.Do(func() {
 		n.controllerID = registry.GetID(n.hostname)

--- a/events/controller/mock_conditionStatusPublisher.go
+++ b/events/controller/mock_conditionStatusPublisher.go
@@ -26,8 +26,21 @@ func (_m *MockConditionStatusPublisher) EXPECT() *MockConditionStatusPublisher_E
 }
 
 // Publish provides a mock function with given fields: ctx, serverID, state, status
-func (_m *MockConditionStatusPublisher) Publish(ctx context.Context, serverID string, state condition.State, status json.RawMessage) {
-	_m.Called(ctx, serverID, state, status)
+func (_m *MockConditionStatusPublisher) Publish(ctx context.Context, serverID string, state condition.State, status json.RawMessage) error {
+	ret := _m.Called(ctx, serverID, state, status)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Publish")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, condition.State, json.RawMessage) error); ok {
+		r0 = rf(ctx, serverID, state, status)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // MockConditionStatusPublisher_Publish_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Publish'
@@ -51,12 +64,12 @@ func (_c *MockConditionStatusPublisher_Publish_Call) Run(run func(ctx context.Co
 	return _c
 }
 
-func (_c *MockConditionStatusPublisher_Publish_Call) Return() *MockConditionStatusPublisher_Publish_Call {
-	_c.Call.Return()
+func (_c *MockConditionStatusPublisher_Publish_Call) Return(_a0 error) *MockConditionStatusPublisher_Publish_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockConditionStatusPublisher_Publish_Call) RunAndReturn(run func(context.Context, string, condition.State, json.RawMessage)) *MockConditionStatusPublisher_Publish_Call {
+func (_c *MockConditionStatusPublisher_Publish_Call) RunAndReturn(run func(context.Context, string, condition.State, json.RawMessage) error) *MockConditionStatusPublisher_Publish_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/events/controller/mock_conditionStatusPublisher.go
+++ b/events/controller/mock_conditionStatusPublisher.go
@@ -61,6 +61,39 @@ func (_c *MockConditionStatusPublisher_Publish_Call) RunAndReturn(run func(conte
 	return _c
 }
 
+// UpdateTimestamp provides a mock function with given fields: ctx
+func (_m *MockConditionStatusPublisher) UpdateTimestamp(ctx context.Context) {
+	_m.Called(ctx)
+}
+
+// MockConditionStatusPublisher_UpdateTimestamp_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateTimestamp'
+type MockConditionStatusPublisher_UpdateTimestamp_Call struct {
+	*mock.Call
+}
+
+// UpdateTimestamp is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockConditionStatusPublisher_Expecter) UpdateTimestamp(ctx interface{}) *MockConditionStatusPublisher_UpdateTimestamp_Call {
+	return &MockConditionStatusPublisher_UpdateTimestamp_Call{Call: _e.mock.On("UpdateTimestamp", ctx)}
+}
+
+func (_c *MockConditionStatusPublisher_UpdateTimestamp_Call) Run(run func(ctx context.Context)) *MockConditionStatusPublisher_UpdateTimestamp_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockConditionStatusPublisher_UpdateTimestamp_Call) Return() *MockConditionStatusPublisher_UpdateTimestamp_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockConditionStatusPublisher_UpdateTimestamp_Call) RunAndReturn(run func(context.Context)) *MockConditionStatusPublisher_UpdateTimestamp_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockConditionStatusPublisher creates a new instance of MockConditionStatusPublisher. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockConditionStatusPublisher(t interface {

--- a/events/controller/status.go
+++ b/events/controller/status.go
@@ -21,12 +21,17 @@ import (
 )
 
 var (
-	kvTTL = 10 * 24 * time.Hour
+	kvTTL             = 10 * 24 * time.Hour
+	errGetKey         = errors.New("error fetching existing key, value for update")
+	errUnmarshalKey   = errors.New("error unmarshal key, value for update")
+	errWorkerMismatch = errors.New("condition worker mismatch error")
+	errStatusValue    = errors.New("condition status value error")
 )
 
 // ConditionStatusPublisher defines an interface for publishing status updates for conditions.
 type ConditionStatusPublisher interface {
 	Publish(ctx context.Context, serverID string, state condition.State, status json.RawMessage)
+	UpdateTimestamp(ctx context.Context)
 }
 
 // NatsConditionStatusPublisher implements the StatusPublisher interface to publish condition status updates using NATS.

--- a/events/controller/status.go
+++ b/events/controller/status.go
@@ -137,6 +137,7 @@ func (s *NatsConditionStatusPublisher) Publish(ctx context.Context, serverID str
 	var err error
 	var rev uint64
 	if s.lastRev == 0 {
+		sv.CreatedAt = time.Now()
 		rev, err = s.kv.Create(key, sv.MustBytes())
 	} else {
 		rev, err = s.update(key, sv, false)

--- a/events/controller/status.go
+++ b/events/controller/status.go
@@ -414,8 +414,11 @@ func (p *NatsConditionStatusQueryor) ConditionState(conditionID string) Conditio
 
 // eventStatusAcknowleger provides an interface for acknowledging the status of events in a NATS JetStream.
 type eventStatusAcknowleger interface {
+	// inProgress marks the event as being in progress in the NATS JetStream.
 	inProgress()
+	// complete marks the event as complete in the NATS JetStream.
 	complete()
+	// nak sends a negative acknowledgment for the event in the NATS JetStream, indicating it requires further handling.
 	nak()
 }
 

--- a/events/controller/status.go
+++ b/events/controller/status.go
@@ -21,11 +21,11 @@ import (
 )
 
 var (
-	kvTTL             = 10 * 24 * time.Hour
-	errGetKey         = errors.New("error fetching existing key, value for update")
-	errUnmarshalKey   = errors.New("error unmarshal key, value for update")
-	errWorkerMismatch = errors.New("condition worker mismatch error")
-	errStatusValue    = errors.New("condition status value error")
+	kvTTL                 = 10 * 24 * time.Hour
+	errGetKey             = errors.New("error fetching existing key, value for update")
+	errUnmarshalKey       = errors.New("error unmarshal key, value for update")
+	errControllerMismatch = errors.New("condition controller mismatch error")
+	errStatusValue        = errors.New("condition status value error")
 )
 
 // ConditionStatusPublisher defines an interface for publishing status updates for conditions.
@@ -186,7 +186,7 @@ func (s *NatsConditionStatusPublisher) update(key string, newStatusValue *condit
 	}
 
 	if curStatusValue.WorkerID != s.controllerID {
-		return 0, errors.Wrap(errWorkerMismatch, curStatusValue.WorkerID)
+		return 0, errors.Wrap(errControllerMismatch, curStatusValue.WorkerID)
 	}
 
 	var update *condition.StatusValue

--- a/events/controller/status_test.go
+++ b/events/controller/status_test.go
@@ -91,7 +91,8 @@ func TestPublish(t *testing.T) {
 	// publish pending status
 	require.NotPanics(t,
 		func() {
-			publisher.Publish(context.Background(), serverID.String(), condition.Pending, []byte(`{"pending...": "true"}`))
+			errP := publisher.Publish(context.Background(), serverID.String(), condition.Pending, []byte(`{"pending...": "true"}`))
+			require.NoError(t, errP)
 		},
 		"publish pending",
 	)
@@ -112,7 +113,9 @@ func TestPublish(t *testing.T) {
 	// publish active status
 	require.NotPanics(t,
 		func() {
-			publisher.Publish(context.Background(), serverID.String(), condition.Active, []byte(`{"active...": "true"}`))
+			errP := publisher.Publish(context.Background(), serverID.String(), condition.Active, []byte(`{"active...": "true"}`))
+			require.NoError(t, errP)
+
 		},
 		"publish active",
 	)


### PR DESCRIPTION
To keep the orchestrator updated on the current situation of a Condition, we now send periodic updates.
This work will enable the orchestrator to reconcile pending/active Conditions.

For merge after https://github.com/metal-toolbox/rivets/pull/52