### PR TITLE
Condition handler changes

### DIFF
--- a/condition/status.go
+++ b/condition/status.go
@@ -50,6 +50,7 @@ const (
 
 // StatusValue is the canonical structure for reporting status of an ongoing task
 type StatusValue struct {
+	CreatedAt  time.Time       `json:"created"`
 	UpdatedAt  time.Time       `json:"updated"`
 	WorkerID   string          `json:"worker"`
 	Target     string          `json:"target"`

--- a/events/controller/controller.go
+++ b/events/controller/controller.go
@@ -31,15 +31,14 @@ const (
 	pullEventTimeout = 5 * time.Second
 	// Default concurrency
 	concurrency = 2
-	// periodically publish an updated status
-	statusInterval = 30 * time.Second
-	// condition status considered stale after this period
-	StatusStaleThreshold = statusInterval * 4
-
 	// controller check in interval
 	checkinInterval = 30 * time.Second
+	// periodically publish an updated status
+	statusInterval = checkinInterval
+	// condition status considered stale after this period
+	StatusStaleThreshold = condition.StaleThreshold
 	//  controller considered dead after this period
-	LivenessStaleThreshold = checkinInterval * 4
+	LivenessStaleThreshold = condition.StaleThreshold
 	// default number of KV replicas for created NATS buckets
 	kvReplicationFactor = 3
 )

--- a/events/controller/mock_conditionStatusPublisher.go
+++ b/events/controller/mock_conditionStatusPublisher.go
@@ -26,8 +26,21 @@ func (_m *MockConditionStatusPublisher) EXPECT() *MockConditionStatusPublisher_E
 }
 
 // Publish provides a mock function with given fields: ctx, serverID, state, status
-func (_m *MockConditionStatusPublisher) Publish(ctx context.Context, serverID string, state condition.State, status json.RawMessage) {
-	_m.Called(ctx, serverID, state, status)
+func (_m *MockConditionStatusPublisher) Publish(ctx context.Context, serverID string, state condition.State, status json.RawMessage) error {
+	ret := _m.Called(ctx, serverID, state, status)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Publish")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, condition.State, json.RawMessage) error); ok {
+		r0 = rf(ctx, serverID, state, status)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // MockConditionStatusPublisher_Publish_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Publish'
@@ -51,12 +64,12 @@ func (_c *MockConditionStatusPublisher_Publish_Call) Run(run func(ctx context.Co
 	return _c
 }
 
-func (_c *MockConditionStatusPublisher_Publish_Call) Return() *MockConditionStatusPublisher_Publish_Call {
-	_c.Call.Return()
+func (_c *MockConditionStatusPublisher_Publish_Call) Return(_a0 error) *MockConditionStatusPublisher_Publish_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockConditionStatusPublisher_Publish_Call) RunAndReturn(run func(context.Context, string, condition.State, json.RawMessage)) *MockConditionStatusPublisher_Publish_Call {
+func (_c *MockConditionStatusPublisher_Publish_Call) RunAndReturn(run func(context.Context, string, condition.State, json.RawMessage) error) *MockConditionStatusPublisher_Publish_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/events/controller/status.go
+++ b/events/controller/status.go
@@ -137,6 +137,7 @@ func (s *NatsConditionStatusPublisher) Publish(ctx context.Context, serverID str
 	var err error
 	var rev uint64
 	if s.lastRev == 0 {
+		sv.CreatedAt = time.Now()
 		rev, err = s.kv.Create(key, sv.MustBytes())
 	} else {
 		rev, err = s.update(key, sv, false)

--- a/events/controller/status.go
+++ b/events/controller/status.go
@@ -414,8 +414,11 @@ func (p *NatsConditionStatusQueryor) ConditionState(conditionID string) Conditio
 
 // eventStatusAcknowleger provides an interface for acknowledging the status of events in a NATS JetStream.
 type eventStatusAcknowleger interface {
+	// inProgress marks the event as being in progress in the NATS JetStream.
 	inProgress()
+	// complete marks the event as complete in the NATS JetStream.
 	complete()
+	// nak sends a negative acknowledgment for the event in the NATS JetStream, indicating it requires further handling.
 	nak()
 }
 

--- a/events/controller/status_test.go
+++ b/events/controller/status_test.go
@@ -91,7 +91,8 @@ func TestPublish(t *testing.T) {
 	// publish pending status
 	require.NotPanics(t,
 		func() {
-			publisher.Publish(context.Background(), serverID.String(), condition.Pending, []byte(`{"pending...": "true"}`))
+			errP := publisher.Publish(context.Background(), serverID.String(), condition.Pending, []byte(`{"pending...": "true"}`))
+			require.NoError(t, errP)
 		},
 		"publish pending",
 	)
@@ -112,7 +113,9 @@ func TestPublish(t *testing.T) {
 	// publish active status
 	require.NotPanics(t,
 		func() {
-			publisher.Publish(context.Background(), serverID.String(), condition.Active, []byte(`{"active...": "true"}`))
+			errP := publisher.Publish(context.Background(), serverID.String(), condition.Active, []byte(`{"active...": "true"}`))
+			require.NoError(t, errP)
+
 		},
 		"publish active",
 	)


### PR DESCRIPTION
- Create a status KV record for Orchestrator to watch before processing
- Jetstream messages are Ack'ed as Complete, before processing
- Publish() method to return error
- Clean up after a handler panic, initial publish failure

To be merged after https://github.com/metal-toolbox/rivets/pull/53