### PR TITLE
Publisher init

### DIFF
--- a/condition/status.go
+++ b/condition/status.go
@@ -50,6 +50,7 @@ const (
 
 // StatusValue is the canonical structure for reporting status of an ongoing task
 type StatusValue struct {
+	CreatedAt  time.Time       `json:"created"`
 	UpdatedAt  time.Time       `json:"updated"`
 	WorkerID   string          `json:"worker"`
 	Target     string          `json:"target"`

--- a/events/controller/controller.go
+++ b/events/controller/controller.go
@@ -31,15 +31,14 @@ const (
 	pullEventTimeout = 5 * time.Second
 	// Default concurrency
 	concurrency = 2
-	// periodically publish an updated status
-	statusInterval = 30 * time.Second
-	// condition status considered stale after this period
-	StatusStaleThreshold = statusInterval * 4
-
 	// controller check in interval
 	checkinInterval = 30 * time.Second
+	// periodically publish an updated status
+	statusInterval = checkinInterval
+	// condition status considered stale after this period
+	StatusStaleThreshold = condition.StaleThreshold
 	//  controller considered dead after this period
-	LivenessStaleThreshold = checkinInterval * 4
+	LivenessStaleThreshold = condition.StaleThreshold
 	// default number of KV replicas for created NATS buckets
 	kvReplicationFactor = 3
 )

--- a/events/controller/status.go
+++ b/events/controller/status.go
@@ -137,6 +137,7 @@ func (s *NatsConditionStatusPublisher) Publish(ctx context.Context, serverID str
 	var err error
 	var rev uint64
 	if s.lastRev == 0 {
+		sv.CreatedAt = time.Now()
 		rev, err = s.kv.Create(key, sv.MustBytes())
 	} else {
 		rev, err = s.update(key, sv, false)


### PR DESCRIPTION
- Include a `CreatedAt` field in the Conditions Status Value, to help figure when the Status Value key value was created.
- Initialize the NATS publisher with the current revision of the Status Value when available. 