### PR TITLE
condition: define inband fw install Kind, helper methods

### DIFF
--- a/condition/firmware_install.go
+++ b/condition/firmware_install.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	FirmwareInstall Kind = "firmwareInstall"
+	FirmwareInstall       Kind = "firmwareInstall"
+	FirmwareInstallInband Kind = "firmwareInstallInband"
 )
 
 // FirmwareTaskParameters are the parameters set for a firmwareInstall condition
@@ -38,6 +39,23 @@ type FirmwareInstallTaskParameters struct {
 
 	// FirmwareSetID specifies the firmware set to be applied.
 	FirmwareSetID uuid.UUID `json:"firmware_set_id,omitempty"`
+}
+
+func (p *FirmwareInstallTaskParameters) MapStringInterfaceToStruct(m map[string]interface{}) error {
+	jsonData, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(jsonData, p)
+}
+
+func (p *FirmwareInstallTaskParameters) Unmarshal(r json.RawMessage) error {
+	return json.Unmarshal(r, p)
+}
+
+func (p *FirmwareInstallTaskParameters) Marshal() (json.RawMessage, error) {
+	return json.Marshal(p)
 }
 
 func (p *FirmwareInstallTaskParameters) MustJSON() []byte {

--- a/condition/types.go
+++ b/condition/types.go
@@ -2,6 +2,7 @@ package condition
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -138,6 +139,16 @@ type Condition struct {
 
 	// CreatedAt is when this object was created.
 	CreatedAt time.Time `json:"createdAt,omitempty"`
+}
+
+func (c *Condition) StreamPublishSubject(facilityCode string) string {
+	// note: inband install conditions are published with the serverID in the subject suffix
+	if c.Kind == FirmwareInstallInband {
+		return fmt.Sprintf("%s.servers.%s.%s", facilityCode, c.Kind, c.Target.String())
+
+	}
+
+	return fmt.Sprintf("%s.servers.%s", facilityCode, c.Kind)
 }
 
 // Fault is used to introduce faults into the controller when executing on a condition.


### PR DESCRIPTION
The helper methods on the `FirmwareInstallTaskParameters` type assist with packing, unpacking the install parameters. 
The helper method on the `Condition` type returns the stream subject.