### PR TITLE
Condition Status KV publish interface changes

### DIFF
--- a/events/controller/controller.go
+++ b/events/controller/controller.go
@@ -329,7 +329,16 @@ func (n *NatsController) processConditionFromEvent(ctx context.Context, msg even
 	// extract parent trace context from the event if any.
 	ctx = msg.ExtractOtelTraceContext(ctx)
 
-	conditionStatusPublisher, err := n.NewNatsConditionStatusPublisher(cond.ID.String())
+	conditionStatusPublisher, err := NewNatsConditionStatusPublisher(
+		"test",
+		cond.ID.String(),
+		n.facilityCode,
+		cond.Kind,
+		n.liveness.ControllerID(),
+		0,
+		n.stream.(*events.NatsJetstream),
+		n.logger,
+	)
 	if err != nil {
 		n.logger.WithField("conditionID", cond.ID.String()).Warn("failed to initialize publisher")
 		eventAcknowleger.nak()

--- a/events/controller/controller_test.go
+++ b/events/controller/controller_test.go
@@ -190,7 +190,7 @@ func TestProcessCondition(t *testing.T) {
 
 				// expect to publish status in these states
 				cStatusPublisher = NewMockConditionStatusPublisher(t)
-				cStatusPublisher.On("Publish", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				cStatusPublisher.On("Publish", mock.Anything, mock.Anything, mock.Anything, mock.Anything, false).Return(nil)
 			}
 
 			mockLiveness := NewMockLivenessCheckin(t)
@@ -307,8 +307,10 @@ func TestRunConditionHandlerWithMonitor(t *testing.T) {
 					Return(nil)
 
 				message.On("Ack").Return(nil)
-				publisher.On("UpdateTimestamp", mock.Anything).Return(nil)
-				publisher.On("Publish", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				// ts update
+				publisher.On("Publish", mock.Anything, mock.Anything, mock.Anything, mock.Anything, true).Return(nil)
+				// full status update
+				publisher.On("Publish", mock.Anything, mock.Anything, mock.Anything, mock.Anything, false).Return(nil)
 
 				return handler, message, publisher
 			},
@@ -325,7 +327,7 @@ func TestRunConditionHandlerWithMonitor(t *testing.T) {
 					Return(errors.New("barf"))
 
 				message.On("Ack").Return(nil)
-				publisher.On("Publish", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				publisher.On("Publish", mock.Anything, mock.Anything, mock.Anything, mock.Anything, false).Return(nil)
 
 				return handler, message, publisher
 			},
@@ -340,7 +342,7 @@ func TestRunConditionHandlerWithMonitor(t *testing.T) {
 				handler := NewMockConditionHandler(t)
 
 				message.On("Nak").Return(nil)
-				publisher.On("Publish", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("barf"))
+				publisher.On("Publish", mock.Anything, mock.Anything, mock.Anything, mock.Anything, false).Return(errors.New("barf"))
 
 				return handler, message, publisher
 			},
@@ -358,8 +360,8 @@ func TestRunConditionHandlerWithMonitor(t *testing.T) {
 					Run(func(_ mock.Arguments) { panic("oops") })
 
 				message.On("Ack").Return(nil)
-				publisher.On("Publish", mock.Anything, mock.Anything, condition.Pending, mock.Anything).Return(nil)
-				publisher.On("Publish", mock.Anything, mock.Anything, condition.Failed, mock.Anything).Return(nil)
+				publisher.On("Publish", mock.Anything, mock.Anything, condition.Pending, mock.Anything, false).Return(nil)
+				publisher.On("Publish", mock.Anything, mock.Anything, condition.Failed, mock.Anything, false).Return(nil)
 
 				return handler, message, publisher
 			},

--- a/events/controller/mock_conditionStatusPublisher.go
+++ b/events/controller/mock_conditionStatusPublisher.go
@@ -25,17 +25,17 @@ func (_m *MockConditionStatusPublisher) EXPECT() *MockConditionStatusPublisher_E
 	return &MockConditionStatusPublisher_Expecter{mock: &_m.Mock}
 }
 
-// Publish provides a mock function with given fields: ctx, serverID, state, status
-func (_m *MockConditionStatusPublisher) Publish(ctx context.Context, serverID string, state condition.State, status json.RawMessage) error {
-	ret := _m.Called(ctx, serverID, state, status)
+// Publish provides a mock function with given fields: ctx, serverID, state, status, tsUpdateOnly
+func (_m *MockConditionStatusPublisher) Publish(ctx context.Context, serverID string, state condition.State, status json.RawMessage, tsUpdateOnly bool) error {
+	ret := _m.Called(ctx, serverID, state, status, tsUpdateOnly)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Publish")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, condition.State, json.RawMessage) error); ok {
-		r0 = rf(ctx, serverID, state, status)
+	if rf, ok := ret.Get(0).(func(context.Context, string, condition.State, json.RawMessage, bool) error); ok {
+		r0 = rf(ctx, serverID, state, status, tsUpdateOnly)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -53,13 +53,14 @@ type MockConditionStatusPublisher_Publish_Call struct {
 //   - serverID string
 //   - state condition.State
 //   - status json.RawMessage
-func (_e *MockConditionStatusPublisher_Expecter) Publish(ctx interface{}, serverID interface{}, state interface{}, status interface{}) *MockConditionStatusPublisher_Publish_Call {
-	return &MockConditionStatusPublisher_Publish_Call{Call: _e.mock.On("Publish", ctx, serverID, state, status)}
+//   - tsUpdateOnly bool
+func (_e *MockConditionStatusPublisher_Expecter) Publish(ctx interface{}, serverID interface{}, state interface{}, status interface{}, tsUpdateOnly interface{}) *MockConditionStatusPublisher_Publish_Call {
+	return &MockConditionStatusPublisher_Publish_Call{Call: _e.mock.On("Publish", ctx, serverID, state, status, tsUpdateOnly)}
 }
 
-func (_c *MockConditionStatusPublisher_Publish_Call) Run(run func(ctx context.Context, serverID string, state condition.State, status json.RawMessage)) *MockConditionStatusPublisher_Publish_Call {
+func (_c *MockConditionStatusPublisher_Publish_Call) Run(run func(ctx context.Context, serverID string, state condition.State, status json.RawMessage, tsUpdateOnly bool)) *MockConditionStatusPublisher_Publish_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(condition.State), args[3].(json.RawMessage))
+		run(args[0].(context.Context), args[1].(string), args[2].(condition.State), args[3].(json.RawMessage), args[4].(bool))
 	})
 	return _c
 }
@@ -69,40 +70,7 @@ func (_c *MockConditionStatusPublisher_Publish_Call) Return(_a0 error) *MockCond
 	return _c
 }
 
-func (_c *MockConditionStatusPublisher_Publish_Call) RunAndReturn(run func(context.Context, string, condition.State, json.RawMessage) error) *MockConditionStatusPublisher_Publish_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateTimestamp provides a mock function with given fields: ctx
-func (_m *MockConditionStatusPublisher) UpdateTimestamp(ctx context.Context) {
-	_m.Called(ctx)
-}
-
-// MockConditionStatusPublisher_UpdateTimestamp_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateTimestamp'
-type MockConditionStatusPublisher_UpdateTimestamp_Call struct {
-	*mock.Call
-}
-
-// UpdateTimestamp is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *MockConditionStatusPublisher_Expecter) UpdateTimestamp(ctx interface{}) *MockConditionStatusPublisher_UpdateTimestamp_Call {
-	return &MockConditionStatusPublisher_UpdateTimestamp_Call{Call: _e.mock.On("UpdateTimestamp", ctx)}
-}
-
-func (_c *MockConditionStatusPublisher_UpdateTimestamp_Call) Run(run func(ctx context.Context)) *MockConditionStatusPublisher_UpdateTimestamp_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
-	})
-	return _c
-}
-
-func (_c *MockConditionStatusPublisher_UpdateTimestamp_Call) Return() *MockConditionStatusPublisher_UpdateTimestamp_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockConditionStatusPublisher_UpdateTimestamp_Call) RunAndReturn(run func(context.Context)) *MockConditionStatusPublisher_UpdateTimestamp_Call {
+func (_c *MockConditionStatusPublisher_Publish_Call) RunAndReturn(run func(context.Context, string, condition.State, json.RawMessage, bool) error) *MockConditionStatusPublisher_Publish_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/events/controller/status.go
+++ b/events/controller/status.go
@@ -71,7 +71,7 @@ func NewNatsConditionStatusPublisher(
 	}
 
 	// retrieve current key revision if key exists
-	ckey := key(facilityCode, conditionID)
+	ckey := condition.StatusValueKVKey(facilityCode, conditionID)
 	currStatusEntry, errGet := statusKV.Get(ckey)
 	if errGet != nil && !errors.Is(errGet, nats.ErrKeyNotFound) {
 		return nil, errors.Wrap(
@@ -114,7 +114,7 @@ func (s *NatsConditionStatusPublisher) Publish(ctx context.Context, serverID str
 		UpdatedAt: time.Now(),
 	}
 
-	key := key(s.facilityCode, s.conditionID)
+	key := condition.StatusValueKVKey(s.facilityCode, s.conditionID)
 
 	var err error
 	var rev uint64
@@ -303,7 +303,7 @@ func (n *NatsController) NewNatsConditionStatusQueryor() (*NatsConditionStatusQu
 
 // ConditionState queries the NATS KeyValue store to determine the current state of a condition.
 func (p *NatsConditionStatusQueryor) ConditionState(conditionID string) ConditionState {
-	key := key(p.facilityCode, conditionID)
+	key := condition.StatusValueKVKey(p.facilityCode, conditionID)
 	entry, err := p.kv.Get(key)
 	switch err {
 	case nats.ErrKeyNotFound:

--- a/events/controller/status_test.go
+++ b/events/controller/status_test.go
@@ -102,7 +102,13 @@ func TestNewNatsConditionStatusPublisher(t *testing.T) {
 	serverID := uuid.New()
 	require.NotPanics(t,
 		func() {
-			errP := publisher.Publish(context.Background(), serverID.String(), condition.Pending, []byte(`{"pending...": "true"}`))
+			errP := publisher.Publish(
+				context.Background(),
+				serverID.String(),
+				condition.Pending,
+				[]byte(`{"pending...": "true"}`),
+				false,
+			)
 			require.NoError(t, errP)
 		},
 		"publish 1",
@@ -126,7 +132,13 @@ func TestNewNatsConditionStatusPublisher(t *testing.T) {
 
 	require.NotPanics(t,
 		func() {
-			errP := publisher.Publish(context.Background(), serverID.String(), condition.Active, []byte(`{"some work...": "true"}`))
+			errP := publisher.Publish(
+				context.Background(),
+				serverID.String(),
+				condition.Active,
+				[]byte(`{"some work...": "true"}`),
+				false,
+			)
 			require.NoError(t, errP)
 		},
 		"publish 2",
@@ -178,7 +190,12 @@ func TestPublish(t *testing.T) {
 	// publish pending status
 	require.NotPanics(t,
 		func() {
-			errP := publisher.Publish(context.Background(), serverID.String(), condition.Pending, []byte(`{"pending...": "true"}`))
+			errP := publisher.Publish(
+				context.Background(), serverID.String(),
+				condition.Pending,
+				[]byte(`{"pending...": "true"}`),
+				false,
+			)
 			require.NoError(t, errP)
 		},
 		"publish pending",
@@ -200,7 +217,13 @@ func TestPublish(t *testing.T) {
 	// publish active status
 	require.NotPanics(t,
 		func() {
-			errP := publisher.Publish(context.Background(), serverID.String(), condition.Active, []byte(`{"active...": "true"}`))
+			errP := publisher.Publish(
+				context.Background(),
+				serverID.String(),
+				condition.Active,
+				[]byte(`{"active...": "true"}`),
+				false,
+			)
 			require.NoError(t, errP)
 
 		},

--- a/events/controller/status_test.go
+++ b/events/controller/status_test.go
@@ -71,19 +71,26 @@ func TestNewNatsConditionStatusPublisher(t *testing.T) {
 
 	const facilityCode = "fac13"
 	controllerID := registry.GetID("test")
-	mockLiveness := NewMockLivenessCheckin(t)
-	mockLiveness.On("ControllerID").Return(controllerID)
 
 	controller := &NatsController{
 		stream:        evJS,
 		facilityCode:  facilityCode,
 		conditionKind: cond.Kind,
 		logger:        logrus.New(),
-		liveness:      mockLiveness,
 	}
 
 	// test happy case
-	publisher, err := controller.NewNatsConditionStatusPublisher(cond.ID.String())
+	publisher, err := NewNatsConditionStatusPublisher(
+		"test",
+		cond.ID.String(),
+		facilityCode,
+		cond.Kind,
+		controllerID,
+		0,
+		evJS,
+		controller.logger,
+	)
+
 	require.Nil(t, err)
 	require.NotNil(t, publisher, "publisher constructor")
 
@@ -102,7 +109,17 @@ func TestNewNatsConditionStatusPublisher(t *testing.T) {
 	)
 	require.Equal(t, uint64(1), publisher.lastRev)
 
-	publisher, err = controller.NewNatsConditionStatusPublisher(cond.ID.String())
+	publisher, err = NewNatsConditionStatusPublisher(
+		"test",
+		cond.ID.String(),
+		facilityCode,
+		cond.Kind,
+		controllerID,
+		0,
+		evJS,
+		controller.logger,
+	)
+
 	require.Nil(t, err)
 	require.NotNil(t, publisher, "publisher constructor")
 	require.Equal(t, uint64(1), publisher.lastRev)
@@ -132,18 +149,24 @@ func TestPublish(t *testing.T) {
 	const facilityCode = "fac13"
 
 	controllerID := registry.GetID("test")
-	mockLiveness := NewMockLivenessCheckin(t)
-	mockLiveness.On("ControllerID").Return(controllerID)
 
 	controller := &NatsController{
 		stream:        evJS,
 		facilityCode:  facilityCode,
 		conditionKind: cond.Kind,
 		logger:        logrus.New(),
-		liveness:      mockLiveness,
 	}
 
-	publisher, err := controller.NewNatsConditionStatusPublisher(cond.ID.String())
+	publisher, err := NewNatsConditionStatusPublisher(
+		"test",
+		cond.ID.String(),
+		facilityCode,
+		cond.Kind,
+		controllerID,
+		0,
+		evJS,
+		controller.logger,
+	)
 	require.Nil(t, err)
 	require.NotNil(t, publisher, "publisher constructor")
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/prometheus/client_golang v1.19.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
-	go.hollow.sh/toolbox v0.6.3
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/trace v1.27.0
@@ -90,6 +89,7 @@ require (
 	github.com/volatiletech/sqlboiler v3.7.1+incompatible // indirect
 	github.com/volatiletech/sqlboiler/v4 v4.16.2 // indirect
 	github.com/volatiletech/strmangle v0.0.6 // indirect
+	go.hollow.sh/toolbox v0.6.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.27.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect


### PR DESCRIPTION
- Moves `NewNatsConditionStatusPublisher` constructor off the events `Controller{}` type
- Moves `UpdateTimestamp()` functionality into `Publish()` and removes `UpdateTimestamp()`. 

This work prepares the way to add in the HTTPs based controller implementations