### PR TITLE
condition/consts: move threshold consts from cntlr lib to here

### DIFF
--- a/condition/consts.go
+++ b/condition/consts.go
@@ -2,6 +2,14 @@ package condition
 
 import "fmt"
 
+const (
+	// condition status considered stale after this period
+	StatusStaleThreshold = StaleThreshold
+
+	// controller considered dead after this period
+	LivenessStaleThreshold = StaleThreshold
+)
+
 // Returns the stream subject with which the condition is to be published.
 func StreamSubject(facilityCode string, conditionKind Kind) string {
 	return fmt.Sprintf("%s.servers.%s", facilityCode, conditionKind)


### PR DESCRIPTION
So that all condition related consts are in one place and the Orchestrator does not have to import the cntlr library

https://github.com/metal-toolbox/cntlr/blob/e33588550105db7d06a1768c54bfde4a7cc5d1ee/controller.go#L39