### PR TITLE
Refine datatype of ValidateFirmwareTimeout parameter

### DIFF
--- a/condition/server_control.go
+++ b/condition/server_control.go
@@ -2,6 +2,7 @@ package condition
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -80,9 +81,9 @@ type ServerControlTaskParameters struct {
 	// Required: false
 	SetNextBootDeviceEFI bool `json:"set_next_boot_device_efi"`
 
-	// The timeout in seconds for a ValidateFirmware action
+	// The timeout for a ValidateFirmware action
 	// Required for ValidateFirmware.
-	ValidateFirmwareTimeout uint `json:"validate_firmware_timeout"`
+	ValidateFirmwareTimeout time.Duration `json:"validate_firmware_timeout"`
 }
 
 func (p *ServerControlTaskParameters) Unmarshal(r json.RawMessage) error {


### PR DESCRIPTION
It's a length of time, so let's make it a Duration instead of an integer of an implicit unit.

(Pursuant to @DoctorVin's suggestion [here](https://github.com/metal-toolbox/flipflop/pull/8#discussion_r1714280886).)