### PR TITLE
events/registry: GetIDWithUUID() returns a ControllerID using the give UUID

### DIFF
--- a/events/registry/types.go
+++ b/events/registry/types.go
@@ -60,6 +60,13 @@ func GetID(app string) ControllerID {
 	}
 }
 
+func GetIDWithUUID(app string, id uuid.UUID) ControllerID {
+	return &workerUUID{
+		appName: app,
+		uuid:    id,
+	}
+}
+
 type activityRecord struct {
 	LastActive time.Time `json:"last_active"`
 }


### PR DESCRIPTION
This enables a caller to create a custom ControllerID for use by controllers that are not ephemeral - like flasher inband.