### PR TITLE
events/nats_config: higher default connection timeout

### DIFF
--- a/events/nats_config.go
+++ b/events/nats_config.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// nats server connection timeout
-	connectTimeout = 100 * time.Millisecond
+	connectTimeout = 60 * time.Second
 
 	// reconnect jitter
 	reconnectJitter = 10 * time.Second


### PR DESCRIPTION
100ms is too low and results in context timeouts when interacting with the stream in practical senarios