### PR TITLE
Change bios_config_url to string so that it can be unmarshalled

### DIFF
--- a/condition/bios_control.go
+++ b/condition/bios_control.go
@@ -2,7 +2,6 @@ package condition
 
 import (
 	"encoding/json"
-	"net/url"
 
 	"github.com/google/uuid"
 )
@@ -38,7 +37,7 @@ type BiosControlTaskParameters struct {
 	// Needed for BiosControlAction.SetConfig
 	//
 	// Required: false
-	BiosConfigURL *url.URL `json:"bios_config_url,omitempty"`
+	BiosConfigURL string `json:"bios_config_url,omitempty"`
 }
 
 func (p *BiosControlTaskParameters) Unmarshal(r json.RawMessage) error {
@@ -57,7 +56,7 @@ func (p *BiosControlTaskParameters) MustJSON() []byte {
 	return byt
 }
 
-func NewBiosControlTaskParameters(assetID uuid.UUID, action BiosControlAction, configURL *url.URL) *BiosControlTaskParameters {
+func NewBiosControlTaskParameters(assetID uuid.UUID, action BiosControlAction, configURL string) *BiosControlTaskParameters {
 	return &BiosControlTaskParameters{
 		AssetID:       assetID,
 		Action:        action,


### PR DESCRIPTION
url.URL doesn't support JSON marshalling. This sets the datatype to string. There are likely knock-on effect for this change but since we aren't doing biosconfig in production, we can deal with them as they come up in testing. 

Right now, this is erroring out when HTTP requests come in from EMAPI because the JSON string cannot be unmarshalled into a url.URL.