### PR TITLE
Bios config url unmarshalling fix

### DIFF
--- a/condition/bios_control.go
+++ b/condition/bios_control.go
@@ -2,7 +2,6 @@ package condition
 
 import (
 	"encoding/json"
-	"net/url"
 
 	"github.com/google/uuid"
 )
@@ -38,7 +37,7 @@ type BiosControlTaskParameters struct {
 	// Needed for BiosControlAction.SetConfig
 	//
 	// Required: false
-	BiosConfigURL *url.URL `json:"bios_config_url,omitempty"`
+	BiosConfigURL string `json:"bios_config_url,omitempty"`
 }
 
 func (p *BiosControlTaskParameters) Unmarshal(r json.RawMessage) error {
@@ -57,7 +56,7 @@ func (p *BiosControlTaskParameters) MustJSON() []byte {
 	return byt
 }
 
-func NewBiosControlTaskParameters(assetID uuid.UUID, action BiosControlAction, configURL *url.URL) *BiosControlTaskParameters {
+func NewBiosControlTaskParameters(assetID uuid.UUID, action BiosControlAction, configURL string) *BiosControlTaskParameters {
 	return &BiosControlTaskParameters{
 		AssetID:       assetID,
 		Action:        action,

--- a/condition/bios_control.go
+++ b/condition/bios_control.go
@@ -2,6 +2,7 @@ package condition
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"github.com/google/uuid"
 )
@@ -37,8 +38,10 @@ type BiosControlTaskParameters struct {
 	// Needed for BiosControlAction.SetConfig
 	//
 	// Required: false
-	BiosConfigURL string `json:"bios_config_url,omitempty"`
+	BiosConfigURL *ConfigURL `json:"bios_config_url,omitempty"`
 }
+
+type ConfigURL url.URL
 
 func (p *BiosControlTaskParameters) Unmarshal(r json.RawMessage) error {
 	return json.Unmarshal(r, p)
@@ -56,7 +59,7 @@ func (p *BiosControlTaskParameters) MustJSON() []byte {
 	return byt
 }
 
-func NewBiosControlTaskParameters(assetID uuid.UUID, action BiosControlAction, configURL string) *BiosControlTaskParameters {
+func NewBiosControlTaskParameters(assetID uuid.UUID, action BiosControlAction, configURL *ConfigURL) *BiosControlTaskParameters {
 	return &BiosControlTaskParameters{
 		AssetID:       assetID,
 		Action:        action,

--- a/condition/helpers.go
+++ b/condition/helpers.go
@@ -19,9 +19,3 @@ func (u *ConfigURL) UnmarshalJSON(data []byte) error {
 	*u = ConfigURL(*parsedURL)
 	return nil
 }
-
-// nolint: gocritic
-func (u ConfigURL) MarshalJSON() ([]byte, error) {
-	parsedURL := url.URL(u)
-	return json.Marshal(parsedURL.String())
-}

--- a/condition/helpers.go
+++ b/condition/helpers.go
@@ -1,0 +1,27 @@
+package condition
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+func (u *ConfigURL) UnmarshalJSON(data []byte) error {
+	var rawURL string
+	if err := json.Unmarshal(data, &rawURL); err != nil {
+		return err
+	}
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+
+	*u = ConfigURL(*parsedURL)
+	return nil
+}
+
+// nolint: gocritic
+func (u ConfigURL) MarshalJSON() ([]byte, error) {
+	parsedURL := url.URL(u)
+	return json.Marshal(parsedURL.String())
+}

--- a/condition/helpers.go
+++ b/condition/helpers.go
@@ -19,3 +19,9 @@ func (u *ConfigURL) UnmarshalJSON(data []byte) error {
 	*u = ConfigURL(*parsedURL)
 	return nil
 }
+
+// nolint: gocritic
+func (u ConfigURL) MarshalJSON() ([]byte, error) {
+	parsedURL := url.URL(u)
+	return json.Marshal(parsedURL.String())
+}


### PR DESCRIPTION
url.URL doesn't have a way to unmarshal from a JSON string. Thus, we cannot use the url.URL type for BiosConfigURL on the BiosControlTaskParameters struct when working with HTTP requests to conditionorc that set the bios configuration from a config file stored at a URL.
To solve this, I have wrapped the url.URL type in a custom type and then implemented the unmarshal json structs.

Ran the sandbox locally and it worked correctly to create the condition.